### PR TITLE
Fixed kill process for bitwindowd on Windows

### DIFF
--- a/public/modules/chainManager.js
+++ b/public/modules/chainManager.js
@@ -386,7 +386,27 @@ class ChainManager {
             await Promise.all([
               new Promise(resolve => killBitWindow.on('exit', resolve)),
               new Promise(resolve => killBitWindowd.on('exit', resolve))
+            ]); 
+          } else if (process.platform === 'win32') {
+            // On Windows, kill both processes
+            const killBitWindow = spawn('taskkill', ['/F', '/IM', 'bitwindow.exe']);
+            const killBitWindowd = spawn('taskkill', ['/F', '/IM', 'bitwindowd.exe']);
+            
+            await Promise.all([
+              new Promise(resolve => killBitWindow.on('exit', resolve)),
+              new Promise(resolve => killBitWindowd.on('exit', resolve))
             ]);
+          } else {
+           // On Linux, kill both processes
+            const killBitWindow = spawn('pkill', ['bitwindow']);
+            const killBitWindowd = spawn('pkill', ['bitwindowd']);
+            
+            await Promise.all([
+              new Promise(resolve => killBitWindow.on('exit', resolve)),
+              new Promise(resolve => killBitWindowd.on('exit', resolve))
+            ]);
+          }
+        }
 
             // Let the process checker detect the stop and update status
             await new Promise(resolve => {


### PR DESCRIPTION
Changed the stopChain function to terminate bitwindowd on Windows. The Safe Stop and Stop button next to Bitwindow would close the gui, but bitwindowd continued to run in the background. This caused issues with updating because the binary could not be deleted.