### PR TITLE
Delete very old folders on reset

### DIFF
--- a/public/chain_config.json
+++ b/public/chain_config.json
@@ -115,7 +115,19 @@
                 },
                 "wallet": ""
             },
-            "extra_delete": ["Library/Application Support/com.layertwolabs.bitwindow", "Library/AppData/Roaming/com.layertwolabs.bitwindow", "Library/AppData/Roaming/com.example", ".local/share/com.layertwolabs.bitwindow"],
+            "extra_delete": [
+                "Library/AppData/Roaming/com.layertwolabs.bitwindow",
+                "Library/AppData/Roaming/com.example",
+                ".local/share/com.layertwolabs.bitwindow",
+                "Library/Application Support/com.layertwolabs.bitwindow",
+                "Library/Application Support/com.layertwolabs.launcher",
+                "Library/Application Support/bitwindowd",
+                "Library/Application Support/cusf_launcher",
+                "Library/Application Support/com.layertwolabs.zsail",
+                "Library/Application Support/drivechain_launcher",
+                "Library/Application Support/drivechain_launcher_sidechains",
+                "Library/Application Support/ZcashDrivechain",  
+            ],
             "extract_dir": {
                 "linux": "Drivechain-Launcher-Downloads/bitwindow",
                 "darwin": "Drivechain-Launcher-Downloads/bitwindow",


### PR DESCRIPTION
People who have used the software for a while still have old folders that do not delete on a full reset. I added them to the extra_delete property.