### PR TITLE
Increased window height, and reset drivechain-launcher folder

### DIFF
--- a/public/chain_config.json
+++ b/public/chain_config.json
@@ -116,9 +116,9 @@
                 "wallet": ""
             },
             "extra_delete": [
-                "Library/AppData/Roaming/com.layertwolabs.bitwindow",
-                "Library/AppData/Roaming/drivechain-launcher",
-                "Library/AppData/Roaming/com.example",
+                "AppData/Roaming/com.layertwolabs.bitwindow",
+                "AppData/Roaming/drivechain-launcher",
+                "AppData/Roaming/com.example",
                 ".local/share/com.layertwolabs.bitwindow",
                 ".config/drivechain-launcher",
                 "Library/Application Support/com.layertwolabs.bitwindow",

--- a/public/chain_config.json
+++ b/public/chain_config.json
@@ -117,13 +117,16 @@
             },
             "extra_delete": [
                 "Library/AppData/Roaming/com.layertwolabs.bitwindow",
+                "Library/AppData/Roaming/drivechain-launcher",
                 "Library/AppData/Roaming/com.example",
                 ".local/share/com.layertwolabs.bitwindow",
+                ".config/drivchain-launcher",
                 "Library/Application Support/com.layertwolabs.bitwindow",
                 "Library/Application Support/com.layertwolabs.launcher",
                 "Library/Application Support/bitwindowd",
                 "Library/Application Support/cusf_launcher",
                 "Library/Application Support/com.layertwolabs.zsail",
+                "Library/Application Support/drivechain-launcher",
                 "Library/Application Support/drivechain_launcher",
                 "Library/Application Support/drivechain_launcher_sidechains",
                 "Library/Application Support/ZcashDrivechain"

--- a/public/chain_config.json
+++ b/public/chain_config.json
@@ -120,7 +120,7 @@
                 "Library/AppData/Roaming/drivechain-launcher",
                 "Library/AppData/Roaming/com.example",
                 ".local/share/com.layertwolabs.bitwindow",
-                ".config/drivchain-launcher",
+                ".config/drivechain-launcher",
                 "Library/Application Support/com.layertwolabs.bitwindow",
                 "Library/Application Support/com.layertwolabs.launcher",
                 "Library/Application Support/bitwindowd",

--- a/public/electron.js
+++ b/public/electron.js
@@ -84,7 +84,7 @@ function createWindow() {
     // Create main window completely hidden
     const options = {
       width: 900,
-      height: 400,
+      height: 450,
       show: false,
       frame: true,
       resizable: false,

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -126,8 +126,7 @@ const SettingsModal = ({ onResetComplete }) => {
       // Delete wallet starters directory first
       await window.electronAPI.invoke('delete-wallet-starters-dir');
       
-      // Recreate wallet starters directories
-      await window.electronAPI.invoke('init-wallet-dirs');
+
 
       // Then handle chain resets
       const chains = await window.electronAPI.getConfig();
@@ -143,6 +142,8 @@ const SettingsModal = ({ onResetComplete }) => {
         }
       }
       setShowResetModal(false);
+      // Recreate wallet starters directories
+      await window.electronAPI.invoke('init-wallet-dirs');
       handleClose(); // Close the settings modal after reset
       onResetComplete(); // Show the welcome modal
     } catch (error) {


### PR DESCRIPTION
Increased the window height by 50px to fix https://github.com/LayerTwo-Labs/Drivechain-Launcher/issues/26 and https://github.com/LayerTwo-Labs/Drivechain-Launcher/issues/30

Delete the drivechain-launcher folder on reset, and repopulate new wallet starters 

Confirmed this works on every OS